### PR TITLE
Fix missing icon name for appstream-compose

### DIFF
--- a/com.visualstudio.code.oss.json
+++ b/com.visualstudio.code.oss.json
@@ -6,6 +6,7 @@
     "runtime-version": "1.4",
     "sdk": "org.freedesktop.Sdk",
     "command": "code-oss",
+    "rename-icon": "com.visualstudio.code.oss",
     "finish-args": [
         "--share=ipc",
         "--socket=x11",


### PR DESCRIPTION
https://phabricator.endlessm.com/T14296